### PR TITLE
Add CommandParameterContextExtensions and ITypeResolverExtensions for service resolution

### DIFF
--- a/src/Spectre.Console.Cli.Extensions.DependencyInjection/CommandParameterContextExtensions.cs
+++ b/src/Spectre.Console.Cli.Extensions.DependencyInjection/CommandParameterContextExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Spectre.Console.Cli.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extension methods for resolving services from a <see cref="CommandParameterContext"/>.
+    /// </summary>
+    public static class CommandParameterContextExtensions
+    {
+        /// <summary>
+        /// Gets a service of type <typeparamref name="T"/> from the context's resolver.
+        /// </summary>
+        /// <typeparam name="T">The type of service to get.</typeparam>
+        /// <param name="context">The command parameter context.</param>
+        /// <returns>A service of type <typeparamref name="T"/> or null if not found.</returns>
+        public static T GetService<T>(this CommandParameterContext context)
+            where T : class
+            => context?.Resolver.GetService<T>();
+
+        /// <summary>
+        /// Gets a required service of type <typeparamref name="T"/> from the context's resolver.
+        /// </summary>
+        /// <typeparam name="T">The type of service to get.</typeparam>
+        /// <param name="context">The command parameter context.</param>
+        /// <returns>A service of type <typeparamref name="T"/>.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the service cannot be resolved.</exception>
+        public static T GetRequiredService<T>(this CommandParameterContext context)
+            where T : class
+            => context?.Resolver.GetService<T>() ?? throw new InvalidOperationException($"Failed to resolve {typeof(T)}");
+    }
+}

--- a/src/Spectre.Console.Cli.Extensions.DependencyInjection/DependencyInjectionRegistrar.cs
+++ b/src/Spectre.Console.Cli.Extensions.DependencyInjection/DependencyInjectionRegistrar.cs
@@ -1,21 +1,32 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Console.Cli;
 
 namespace Spectre.Console.Cli.Extensions.DependencyInjection
 {
+    /// <summary>
+    /// A type registrar that uses Microsoft.Extensions.DependencyInjection for dependency injection.
+    /// </summary>
     public class DependencyInjectionRegistrar : ITypeRegistrar, IDisposable
     {
         private IServiceCollection Services { get; }
         private IList<IDisposable> BuiltProviders { get; }
+        private bool _disposed;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DependencyInjectionRegistrar"/> class.
+        /// </summary>
+        /// <param name="services">The service collection to register services with.</param>
         public DependencyInjectionRegistrar(IServiceCollection services)
         {
             Services = services;
             BuiltProviders = new List<IDisposable>();
         }
 
+        /// <summary>
+        /// Builds the type resolver.
+        /// </summary>
+        /// <returns>A type resolver that can resolve registered services.</returns>
         public ITypeResolver Build()
         {
             var buildServiceProvider = Services.BuildServiceProvider();
@@ -23,27 +34,65 @@ namespace Spectre.Console.Cli.Extensions.DependencyInjection
             return new DependencyInjectionResolver(buildServiceProvider);
         }
 
+        /// <summary>
+        /// Registers a service type with its implementation type.
+        /// </summary>
+        /// <param name="service">The service type to register.</param>
+        /// <param name="implementation">The implementation type.</param>
         public void Register(Type service, Type implementation)
         {
             Services.AddSingleton(service, implementation);
         }
 
+        /// <summary>
+        /// Registers a service type with an implementation instance.
+        /// </summary>
+        /// <param name="service">The service type to register.</param>
+        /// <param name="implementation">The implementation instance.</param>
         public void RegisterInstance(Type service, object implementation)
         {
             Services.AddSingleton(service, implementation);
         }
 
+        /// <summary>
+        /// Registers a service type with a factory that creates the implementation.
+        /// </summary>
+        /// <param name="service">The service type to register.</param>
+        /// <param name="factory">The factory that creates the service implementation.</param>
         public void RegisterLazy(Type service, Func<object> factory)
         {
             Services.AddSingleton(service, _ => factory());
         }
 
+        /// <summary>
+        /// Disposes all built service providers.
+        /// </summary>
         public void Dispose()
         {
-            foreach (var provider in BuiltProviders)
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the <see cref="DependencyInjectionRegistrar"/> and optionally releases the managed resources.
+        /// </summary>
+        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
             {
-                provider.Dispose();
+                return;
             }
+
+            if (disposing)
+            {
+                foreach (var provider in BuiltProviders)
+                {
+                    provider.Dispose();
+                }
+            }
+
+            _disposed = true;
         }
     }
 }

--- a/src/Spectre.Console.Cli.Extensions.DependencyInjection/DependencyInjectionResolver.cs
+++ b/src/Spectre.Console.Cli.Extensions.DependencyInjection/DependencyInjectionResolver.cs
@@ -1,6 +1,5 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Console.Cli;
 
 namespace Spectre.Console.Cli.Extensions.DependencyInjection
 {

--- a/src/Spectre.Console.Cli.Extensions.DependencyInjection/ITypeResolverExtensions.cs
+++ b/src/Spectre.Console.Cli.Extensions.DependencyInjection/ITypeResolverExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Spectre.Console.Cli.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extension methods for resolving services from an <see cref="ITypeResolver"/>.
+    /// </summary>
+    public static class ITypeResolverExtensions
+    {
+        /// <summary>
+        /// Gets a service of type <typeparamref name="T"/> from the resolver.
+        /// </summary>
+        /// <typeparam name="T">The type of service to get.</typeparam>
+        /// <param name="resolver">The type resolver.</param>
+        /// <returns>A service of type <typeparamref name="T"/> or null if not found.</returns>
+        public static T GetService<T>(this ITypeResolver resolver)
+            where T : class
+            => resolver.Resolve(typeof(T)) as T;
+
+        /// <summary>
+        /// Gets a required service of type <typeparamref name="T"/> from the resolver.
+        /// </summary>
+        /// <typeparam name="T">The type of service to get.</typeparam>
+        /// <param name="resolver">The type resolver.</param>
+        /// <returns>A service of type <typeparamref name="T"/>.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the service cannot be resolved.</exception>
+        public static T GetRequiredService<T>(this ITypeResolver resolver)
+            where T : class
+            => resolver.Resolve(typeof(T)) as T ?? throw new InvalidOperationException($"Failed to resolve {typeof(T)}");
+    }
+}

--- a/src/Spectre.Console.Cli.Extensions.DependencyInjection/Spectre.Console.Cli.Extensions.DependencyInjection.csproj
+++ b/src/Spectre.Console.Cli.Extensions.DependencyInjection/Spectre.Console.Cli.Extensions.DependencyInjection.csproj
@@ -12,6 +12,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/wcomab/Spectre.Console.Cli.Extensions.DependencyInjection</PackageProjectUrl>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />


### PR DESCRIPTION
- Introduced CommandParameterContextExtensions to provide extension methods for resolving services from CommandParameterContext.
- Added ITypeResolverExtensions to facilitate service resolution from ITypeResolver.
- Updated DependencyInjectionRegistrar to improve documentation and ensure proper disposal of resources.
- Enabled documentation file generation in the project file.