### PR TITLE
fix: inverted dependencies per target framework net8 -> 9.0.x

### DIFF
--- a/src/Spectre.Console.Cli.Extensions.DependencyInjection/Spectre.Console.Cli.Extensions.DependencyInjection.csproj
+++ b/src/Spectre.Console.Cli.Extensions.DependencyInjection/Spectre.Console.Cli.Extensions.DependencyInjection.csproj
@@ -17,8 +17,8 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Fix inverted dependencies on .net 8 and .net 9 TFM packages