### PR TITLE
Upgrade Spectre.Console.Cli from 0.53.1 to 0.55.0.

### DIFF
--- a/samples/InfoCommand.cs
+++ b/samples/InfoCommand.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Threading;
 using Spectre.Console.Cli;
 
 namespace samples
@@ -11,7 +11,7 @@ namespace samples
         {
             _greetingService = greetingService;
         }
-        public override int Execute(CommandContext context, Settings settings)
+        protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
         {
             _greetingService.Greet("World");
             return 0;

--- a/src/Spectre.Console.Cli.Extensions.DependencyInjection.sln
+++ b/src/Spectre.Console.Cli.Extensions.DependencyInjection.sln
@@ -1,9 +1,11 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Spectre.Console.Cli.Extensions.DependencyInjection", "Spectre.Console.Cli.Extensions.DependencyInjection\Spectre.Console.Cli.Extensions.DependencyInjection.csproj", "{55BC8767-759C-48CD-A927-F5A907E1712F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example", "..\samples\Example.csproj", "{448EDD4E-DDC6-421A-9440-C06B27B7DF3C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,9 +15,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{55BC8767-759C-48CD-A927-F5A907E1712F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -30,5 +29,20 @@ Global
 		{55BC8767-759C-48CD-A927-F5A907E1712F}.Release|x64.Build.0 = Release|x64
 		{55BC8767-759C-48CD-A927-F5A907E1712F}.Release|x86.ActiveCfg = Release|x86
 		{55BC8767-759C-48CD-A927-F5A907E1712F}.Release|x86.Build.0 = Release|x86
+		{448EDD4E-DDC6-421A-9440-C06B27B7DF3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{448EDD4E-DDC6-421A-9440-C06B27B7DF3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{448EDD4E-DDC6-421A-9440-C06B27B7DF3C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{448EDD4E-DDC6-421A-9440-C06B27B7DF3C}.Debug|x64.Build.0 = Debug|Any CPU
+		{448EDD4E-DDC6-421A-9440-C06B27B7DF3C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{448EDD4E-DDC6-421A-9440-C06B27B7DF3C}.Debug|x86.Build.0 = Debug|Any CPU
+		{448EDD4E-DDC6-421A-9440-C06B27B7DF3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{448EDD4E-DDC6-421A-9440-C06B27B7DF3C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{448EDD4E-DDC6-421A-9440-C06B27B7DF3C}.Release|x64.ActiveCfg = Release|Any CPU
+		{448EDD4E-DDC6-421A-9440-C06B27B7DF3C}.Release|x64.Build.0 = Release|Any CPU
+		{448EDD4E-DDC6-421A-9440-C06B27B7DF3C}.Release|x86.ActiveCfg = Release|Any CPU
+		{448EDD4E-DDC6-421A-9440-C06B27B7DF3C}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/Spectre.Console.Cli.Extensions.DependencyInjection/Spectre.Console.Cli.Extensions.DependencyInjection.csproj
+++ b/src/Spectre.Console.Cli.Extensions.DependencyInjection/Spectre.Console.Cli.Extensions.DependencyInjection.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add samples/Example.csproj to the main solution so the sample builds with the library. Update InfoCommand to override the new protected Execute overload that accepts CancellationToken.