### PR TITLE
chore(deps): bump Microsoft.Extensions.DependencyInjection

### DIFF
--- a/samples/Example.csproj
+++ b/samples/Example.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Spectre.Console.Cli.Extensions.DependencyInjection/Spectre.Console.Cli.Extensions.DependencyInjection.csproj
+++ b/src/Spectre.Console.Cli.Extensions.DependencyInjection/Spectre.Console.Cli.Extensions.DependencyInjection.csproj
@@ -18,8 +18,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Align sample and multi-target package references with current patch releases: net9.0 9.0.16, net10.0 and sample 10.0.8.